### PR TITLE
Throttle and retry

### DIFF
--- a/konnected/__init__.py
+++ b/konnected/__init__.py
@@ -1,11 +1,10 @@
 """Python library for interacting with Konnected devices."""
 import asyncio
-import json
-import os
 import aiohttp
 
 
-__author__ = 'Nate Clark, Konnected Inc <help@konnected.io>'
+__author__ = "Nate Clark, Konnected Inc <help@konnected.io>"
+
 
 class Client:
     """API wrapper for Konnected Alarm Panels."""
@@ -16,42 +15,43 @@ class Client:
         self.host = host
         self.port = port
         self.websession = websession
-        self.base_url = 'http://' + host + ':' + port
+        self.base_url = "http://" + host + ":" + port
 
     async def get_status(self, retries=2):
-        """Query the device status. Returns JSON of the device internal state."""
-        url = self.base_url + '/status'
+        """Query the device status."""
+        url = self.base_url + "/status"
         try:
             async with self.throttle:
                 async with self.websession.get(url, timeout=3) as resp:
                     return await resp.json()
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:
             if retries > 0:
-                return await self.get_status(retries-1)
+                return await self.get_status(retries - 1)
             else:
                 raise Client.ClientError(err)
 
     async def get_device(self, pin=None, retries=2):
         """Query the status of a specific pin (or all configured pins if pin is ommitted)."""
-        url = self.base_url + '/device'
+        url = self.base_url + "/device"
         try:
             async with self.throttle:
-                async with self.websession.get(url, params={'pin': pin}, timeout=3) as resp:
+                async with self.websession.get(
+                    url, params={"pin": pin}, timeout=3
+                ) as resp:
                     return await resp.json()
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:
             if retries > 0:
-                return await self.get_device(pin, retries-1)
+                return await self.get_device(pin, retries - 1)
             else:
                 raise Client.ClientError(err)
 
-    async def put_device(self, pin, state, momentary=None, times=None, pause=None, retries=2):
+    async def put_device(
+        self, pin, state, momentary=None, times=None, pause=None, retries=2
+    ):
         """Actuate a device pin."""
-        url = self.base_url + '/device'
+        url = self.base_url + "/device"
 
-        payload = {
-            "pin": pin,
-            "state": state
-        }
+        payload = {"pin": pin, "state": state}
 
         if momentary is not None:
             payload["momentary"] = momentary
@@ -68,31 +68,34 @@ class Client:
                     return await resp.json()
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:
             if retries > 0:
-                return await self.put_device(pin, state, momentary, times, pause, retries-1)
+                return await self.put_device(
+                    pin, state, momentary, times, pause, retries - 1
+                )
             else:
                 raise Client.ClientError(err)
 
     async def get_zone(self, zone=None, retries=2):
         """Query the status of a specific zone (or all configured zones if zones is ommitted)."""
-        url = self.base_url + '/zone'
+        url = self.base_url + "/zone"
         try:
             async with self.throttle:
-                async with self.websession.get(url, params={'zone': zone}, timeout=3) as resp:
+                async with self.websession.get(
+                    url, params={"zone": zone}, timeout=3
+                ) as resp:
                     return await resp.json()
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:
             if retries > 0:
-                return await self.get_zone(zone, retries-1)
+                return await self.get_zone(zone, retries - 1)
             else:
                 raise Client.ClientError(err)
 
-    async def put_zone(self, zone, state, momentary=None, times=None, pause=None, retries=2):
+    async def put_zone(
+        self, zone, state, momentary=None, times=None, pause=None, retries=2
+    ):
         """Actuate a device zone."""
-        url = self.base_url + '/zone'
+        url = self.base_url + "/zone"
 
-        payload = {
-            "zone": zone,
-            "state": state
-        }
+        payload = {"zone": zone, "state": state}
 
         if momentary is not None:
             payload["momentary"] = momentary
@@ -109,15 +112,26 @@ class Client:
                     return await resp.json()
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:
             if retries > 0:
-                return await self.put_zone(zone, state, momentary, times, pause, retries-1)
+                return await self.put_zone(
+                    zone, state, momentary, times, pause, retries - 1
+                )
             else:
                 raise Client.ClientError(err)
 
-    async def put_settings(self, sensors=[], actuators=[], auth_token=None,
-                           endpoint=None, blink=None, discovery=None,
-                           dht_sensors=[], ds18b20_sensors=[], retries=2):
+    async def put_settings(
+        self,
+        sensors=[],
+        actuators=[],
+        auth_token=None,
+        endpoint=None,
+        blink=None,
+        discovery=None,
+        dht_sensors=[],
+        ds18b20_sensors=[],
+        retries=2,
+    ):
         """Sync settings to the Konnected device."""
-        url = self.base_url + '/settings'
+        url = self.base_url + "/settings"
 
         payload = {
             "sensors": sensors or [],
@@ -125,14 +139,14 @@ class Client:
             "dht_sensors": dht_sensors or [],
             "ds18b20_sensors": ds18b20_sensors or [],
             "token": auth_token,
-            "apiUrl": endpoint
+            "apiUrl": endpoint,
         }
 
         if blink is not None:
-            payload['blink'] = blink
+            payload["blink"] = blink
 
         if discovery is not None:
-            payload['discovery'] = discovery
+            payload["discovery"] = discovery
 
         try:
             async with self.throttle:
@@ -140,9 +154,17 @@ class Client:
                     return resp.status >= 200 and resp.status < 300
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:
             if retries > 0:
-                return await self.put_settings(sensors, actuators, auth_token,
-                           endpoint, blink, discovery,
-                           dht_sensors, ds18b20_sensors, retries-1)
+                return await self.put_settings(
+                    sensors,
+                    actuators,
+                    auth_token,
+                    endpoint,
+                    blink,
+                    discovery,
+                    dht_sensors,
+                    ds18b20_sensors,
+                    retries - 1,
+                )
             else:
                 raise Client.ClientError(err)
 

--- a/konnected/__init__.py
+++ b/konnected/__init__.py
@@ -12,30 +12,39 @@ class Client:
 
     def __init__(self, host, port, websession):
         """Initialize the client connection."""
+        self.throttle = asyncio.Semaphore(3)  # allow for 3 simultaneous reqs
         self.host = host
         self.port = port
         self.websession = websession
         self.base_url = 'http://' + host + ':' + port
 
-    async def get_status(self):
+    async def get_status(self, retries=2):
         """Query the device status. Returns JSON of the device internal state."""
         url = self.base_url + '/status'
         try:
-            async with self.websession.get(url, timeout=10) as resp:
-                return await resp.json()
+            async with self.throttle:
+                async with self.websession.get(url, timeout=3) as resp:
+                    return await resp.json()
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:
-            raise Client.ClientError(err)
+            if retries > 0:
+                return await self.get_status(retries-1)
+            else:
+                raise Client.ClientError(err)
 
-    async def get_device(self, pin=None):
+    async def get_device(self, pin=None, retries=2):
         """Query the status of a specific pin (or all configured pins if pin is ommitted)."""
         url = self.base_url + '/device'
         try:
-            async with self.websession.get(url, params={'pin': pin}, timeout=10) as resp:
-                return await resp.json()
+            async with self.throttle:
+                async with self.websession.get(url, params={'pin': pin}, timeout=3) as resp:
+                    return await resp.json()
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:
-            raise Client.ClientError(err)
+            if retries > 0:
+                return await self.get_device(pin, retries-1)
+            else:
+                raise Client.ClientError(err)
 
-    async def put_device(self, pin, state, momentary=None, times=None, pause=None):
+    async def put_device(self, pin, state, momentary=None, times=None, pause=None, retries=2):
         """Actuate a device pin."""
         url = self.base_url + '/device'
 
@@ -54,21 +63,29 @@ class Client:
             payload["pause"] = pause
 
         try:
-            async with self.websession.put(url, json=payload, timeout=10) as resp:
-                return await resp.json()
+            async with self.throttle:
+                async with self.websession.put(url, json=payload, timeout=3) as resp:
+                    return await resp.json()
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:
-            raise Client.ClientError(err)
+            if retries > 0:
+                return await self.put_device(pin, state, momentary, times, pause, retries-1)
+            else:
+                raise Client.ClientError(err)
 
-    async def get_zone(self, zone=None):
+    async def get_zone(self, zone=None, retries=2):
         """Query the status of a specific zone (or all configured zones if zones is ommitted)."""
         url = self.base_url + '/zone'
         try:
-            async with self.websession.get(url, params={'zone': zone}, timeout=10) as resp:
-                return await resp.json()
+            async with self.throttle:
+                async with self.websession.get(url, params={'zone': zone}, timeout=3) as resp:
+                    return await resp.json()
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:
-            raise Client.ClientError(err)
+            if retries > 0:
+                return await self.get_zone(zone, retries-1)
+            else:
+                raise Client.ClientError(err)
 
-    async def put_zone(self, zone, state, momentary=None, times=None, pause=None):
+    async def put_zone(self, zone, state, momentary=None, times=None, pause=None, retries=2):
         """Actuate a device zone."""
         url = self.base_url + '/zone'
 
@@ -87,14 +104,18 @@ class Client:
             payload["pause"] = pause
 
         try:
-            async with self.websession.put(url, json=payload, timeout=10) as resp:
-                return await resp.json()
+            async with self.throttle:
+                async with self.websession.put(url, json=payload, timeout=3) as resp:
+                    return await resp.json()
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:
-            raise Client.ClientError(err)
+            if retries > 0:
+                return await self.put_zone(zone, state, momentary, times, pause, retries-1)
+            else:
+                raise Client.ClientError(err)
 
     async def put_settings(self, sensors=[], actuators=[], auth_token=None,
                            endpoint=None, blink=None, discovery=None,
-                           dht_sensors=[], ds18b20_sensors=[]):
+                           dht_sensors=[], ds18b20_sensors=[], retries=2):
         """Sync settings to the Konnected device."""
         url = self.base_url + '/settings'
 
@@ -114,10 +135,16 @@ class Client:
             payload['discovery'] = discovery
 
         try:
-            async with self.websession.put(url, json=payload, timeout=10) as resp:
-                return resp.status >= 200 and resp.status < 300
+            async with self.throttle:
+                async with self.websession.put(url, json=payload, timeout=3) as resp:
+                    return resp.status >= 200 and resp.status < 300
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:
-            raise Client.ClientError(err)
+            if retries > 0:
+                return await self.put_settings(sensors, actuators, auth_token,
+                           endpoint, blink, discovery,
+                           dht_sensors, ds18b20_sensors, retries-1)
+            else:
+                raise Client.ClientError(err)
 
     class ClientError(Exception):
         """Generic Error."""

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='konnected',
-    version='1.1.0',
+    version='1.2.0',
     packages=['konnected'],
     url='https://github.com/konnected-io/konnected-py',
     description='A async Python library for interacting with Konnected home automation controllers (see https://konnected.io)',


### PR DESCRIPTION
When a client is making rapid requests to a device it will often result in `ClientError` exceptions.  

Upon investigation this is occurring for a two reasons.

1. Multiple async requests can happen in parallel and overload the comms stack of the device.  When this happens, the device will start resetting TCP connections - resulting in the exception.  To avoid this we now use a semaphore to throttle requests such that they are limited to 3 at once.

2. aiohttp will reuse sockets for multiple http requests.  It appears a race condition can occur where the HA client attempts to send a TCP payload after the device has closed the connection via a FIN.  When this happens the device will immediately reset the connection.  To handle this each method now performs retries - in testing this completely mitigated the problem.

In addition to the enhancements above I formatted (black) and linted (flake8) the file. 