### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     packages=['konnected'],
     url='https://github.com/konnected-io/konnected-py',
     description='A async Python library for interacting with Konnected home automation controllers (see https://konnected.io)',
+    license='MIT',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     author='Nate Clark, Konnected Inc',


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.